### PR TITLE
Fix StateTransitionMultiTracker concurrency

### DIFF
--- a/substance/src/main/java/org/pushingpixels/substance/internal/animation/StateTransitionMultiTracker.java
+++ b/substance/src/main/java/org/pushingpixels/substance/internal/animation/StateTransitionMultiTracker.java
@@ -75,7 +75,7 @@ public final class StateTransitionMultiTracker<T> {
 
 				if (!tracker.hasRunningTimelines()) {
 					// System.out.println("Removing tracker for " + id);
-					trackerMap.remove(id);
+					removeTracker(id);
 					tracker.unregisterModelListeners();
 					tracker.removeStateTransitionListener(this);
 				}
@@ -90,12 +90,16 @@ public final class StateTransitionMultiTracker<T> {
 
 				if (!tracker.hasRunningTimelines()) {
 					// System.out.println("Removing tracker for " + id);
-					trackerMap.remove(id);
+					removeTracker(id);
 					tracker.unregisterModelListeners();
 					tracker.removeStateTransitionListener(this);
 				}
 			}
 		};
 		tracker.addStateTransitionListener(listener);
+	}
+	
+	public synchronized void removeTracker(final Comparable<T> id) {
+		trackerMap.remove(id);
 	}
 }


### PR DESCRIPTION
The calls to trackerMap.remove() in the StateTransitionListener methods in the StateTransitionMultiTracker class escape the synchronization that is applied to other uses of the trackerMap field. A synchronized removeTracker method analogous to the addTracker method fixes this.

If the listener methods are called on a different thread than the other (synchronized) methods, the trackerMap can become corrupted, which can lead to deadlocks.